### PR TITLE
Have Parse call flag.Parse, rename ParseFlagSet to Load

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Do:
 // The first parameter to ParseFlagSet is a prefix for all env variables. The
 // empty string disables prefixing env variables.
 //
-// Unlike envflag.Parse, envflag.ParseFlagSet does not call flag.Parse() for
+// Unlike envflag.Parse, envflag.Load does not call flag.Parse() for
 // you. So you'll need to call flag.Parse() yourself.
-envflag.ParseFlagSet("", flag.CommandLine)
+envflag.Load("", flag.CommandLine)
 flag.Parse()
 ```

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ envflag.Parse()
 Do:
 
 ```golang
-// The first parameter to ParseFlagSet is a prefix for all env variables. The
-// empty string disables prefixing env variables.
+// The first parameter to Load is a prefix for all env variables. The empty
+// string disables prefixing env variables.
 //
 // Unlike envflag.Parse, envflag.Load does not call flag.Parse() for
 // you. So you'll need to call flag.Parse() yourself.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ To:
 
 ```golang
 envflag.Parse()
-flag.Parse()
 ```
 
 And you'll get env variable goodness. No further changes required.
@@ -69,7 +68,6 @@ func main() {
   bar := flag.Int("bar", 123, "some int param")
 
   envflag.Parse()
-  flag.Parse()
 
   fmt.Println("foo", *foo)
   fmt.Println("bar", *bar)
@@ -111,8 +109,11 @@ envflag.Parse()
 Do:
 
 ```golang
-// The first parameter to ParseFlagSet is a prefix for all env variables.
+// The first parameter to ParseFlagSet is a prefix for all env variables. The
+// empty string disables prefixing env variables.
 //
-// The empty string disables prefixing env variables.
+// Unlike envflag.Parse, envflag.ParseFlagSet does not call flag.Parse() for
+// you. So you'll need to call flag.Parse() yourself.
 envflag.ParseFlagSet("", flag.CommandLine)
+flag.Parse()
 ```

--- a/envflag.go
+++ b/envflag.go
@@ -21,8 +21,14 @@ import (
 // Parse ultimately calls ParseFlagSet. If you want to parse into another
 // FlagSet than flag.CommandLine, or if you would like to customize or remove
 // the os.Args[0] prefix, then consider using ParseFlagSet instead.
+//
+// Parse will call flag.Parse(). Though there are no negative consequences to
+// calling flag.Parse() after calling flagenv.Parse(), there are no benefits
+// either. If you don't want this package to call flag.Parse(), then use
+// ParseFlagSet instead.
 func Parse() {
 	ParseFlagSet(filepath.Base(os.Args[0]), flag.CommandLine)
+	flag.Parse()
 }
 
 // ParseFlagSet loads environment variables into a flag.FlagSet.

--- a/envflag.go
+++ b/envflag.go
@@ -18,39 +18,38 @@ import (
 // flag.String, flag.Int, etc. functions ultimately get added to
 // flag.CommandLine.
 //
-// Parse ultimately calls ParseFlagSet. If you want to parse into another
-// FlagSet than flag.CommandLine, or if you would like to customize or remove
-// the os.Args[0] prefix, then consider using ParseFlagSet instead.
+// Parse calls Load under the hood. If you want to parse into another FlagSet
+// than flag.CommandLine, or if you would like to customize or remove the
+// os.Args[0] prefix, then consider using Load instead.
 //
 // Parse will call flag.Parse(). Though there are no negative consequences to
 // calling flag.Parse() after calling flagenv.Parse(), there are no benefits
-// either. If you don't want this package to call flag.Parse(), then use
-// ParseFlagSet instead.
+// either. If you don't want this package to call flag.Parse(), then use Load
+// instead.
 func Parse() {
-	ParseFlagSet(filepath.Base(os.Args[0]), flag.CommandLine)
+	Load(filepath.Base(os.Args[0]), flag.CommandLine)
 	flag.Parse()
 }
 
-// ParseFlagSet loads environment variables into a flag.FlagSet.
+// Load loads environment variables into a flag.FlagSet.
 //
 // Environment variables ("env vars") are expected to be named after their
 // corresponding flag's name in upper-case letters, with dashes converted to
 // underscores. If prefix is non-empty, then the env var must be prefixed by
 // prefix (in all caps, with dashes converted to underscores) and an underscore.
 //
-// For example, if prefix is empty, then for a flag named "user-id",
-// ParseFlagSet will look for an env var named "USER_ID". If prefix were instead
-// "count-users", then ParseFlagSet would instead look for an env var named
-// "COUNT_USERS_USER_ID".
+// For example, if prefix is empty, then for a flag named "user-id", Load will
+// look for an env var named "USER_ID". If prefix were instead "count-users",
+// then Load would instead look for an env var named "COUNT_USERS_USER_ID".
 //
 // If an env var for a flag is not found, then that flag is untouched. Whatever
-// value it had before calling ParseFlagSet is preserved.
+// value it had before calling Load is preserved.
 //
 // If an env var for a flag is found, but its value is incompatible with the
 // flag (for example, if an Int flag has a corresponding env var whose value
-// isn't parsable as an int), then ParseFlagSet will trigger an error in
-// correspondence with the ErrorHandling of the given FlagSet.
-func ParseFlagSet(prefix string, fs *flag.FlagSet) error {
+// isn't parsable as an int), then Load will trigger an error in correspondence
+// with the ErrorHandling of the given FlagSet.
+func Load(prefix string, fs *flag.FlagSet) error {
 	var err error
 
 	fs.VisitAll(func(f *flag.Flag) {

--- a/envflag_test.go
+++ b/envflag_test.go
@@ -121,7 +121,7 @@ func TestParseFlagSet(t *testing.T) {
 				b := fs.Int("b", 123, "")
 				c := fs.Bool("has-dashes", false, "")
 
-				assert.NoError(t, envflag.ParseFlagSet("", fs))
+				assert.NoError(t, envflag.Load("", fs))
 				assert.NoError(t, fs.Parse([]string{}))
 
 				assert.Equal(t, "default", *a)
@@ -143,7 +143,7 @@ func TestParseFlagSet(t *testing.T) {
 				b := fs.Int("b", 123, "")
 				c := fs.Bool("has-dashes", false, "")
 
-				assert.NoError(t, envflag.ParseFlagSet("", fs))
+				assert.NoError(t, envflag.Load("", fs))
 				assert.NoError(t, fs.Parse([]string{}))
 
 				assert.Equal(t, "from-env", *a)
@@ -165,7 +165,7 @@ func TestParseFlagSet(t *testing.T) {
 				b := fs.Int("b", 123, "")
 				c := fs.Bool("has-dashes", false, "")
 
-				assert.NoError(t, envflag.ParseFlagSet("", fs))
+				assert.NoError(t, envflag.Load("", fs))
 				assert.NoError(t, fs.Parse([]string{"--a=from-argv"}))
 
 				assert.Equal(t, "from-argv", *a)
@@ -187,7 +187,7 @@ func TestParseFlagSet(t *testing.T) {
 				b := fs.Int("b", 123, "")
 				c := fs.Bool("has-dashes", false, "")
 
-				assert.NoError(t, envflag.ParseFlagSet("some-prefix", fs))
+				assert.NoError(t, envflag.Load("some-prefix", fs))
 				assert.NoError(t, fs.Parse([]string{"--a=from-argv"}))
 
 				assert.Equal(t, "from-argv", *a)
@@ -207,7 +207,7 @@ func TestParseFlagSet(t *testing.T) {
 				fs.Int("b", 123, "")
 
 				assert.Panics(t, func() {
-					envflag.ParseFlagSet("", fs)
+					envflag.Load("", fs)
 				})
 			},
 		},
@@ -222,7 +222,7 @@ func TestParseFlagSet(t *testing.T) {
 				fs := flag.NewFlagSet("", flag.ContinueOnError)
 				fs.Int("b", 123, "")
 
-				assert.Equal(t, "parse error", envflag.ParseFlagSet("", fs).Error())
+				assert.Equal(t, "parse error", envflag.Load("", fs).Error())
 			},
 		},
 	}

--- a/envflag_test.go
+++ b/envflag_test.go
@@ -72,7 +72,6 @@ func TestParseFlagSet(t *testing.T) {
 			env:  map[string]string{},
 			fn: func(t *testing.T) {
 				envflag.Parse()
-				flag.Parse()
 
 				assert.Equal(t, "default-a", *a)
 				assert.Equal(t, 123, *b)
@@ -89,7 +88,6 @@ func TestParseFlagSet(t *testing.T) {
 			},
 			fn: func(t *testing.T) {
 				envflag.Parse()
-				flag.Parse()
 
 				assert.Equal(t, "from-env", *a)
 				assert.Equal(t, 123, *b)
@@ -106,7 +104,6 @@ func TestParseFlagSet(t *testing.T) {
 			},
 			fn: func(t *testing.T) {
 				envflag.Parse()
-				flag.Parse()
 
 				assert.Equal(t, "from-argv", *a)
 				assert.Equal(t, 123, *b)

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -12,7 +12,6 @@ func main() {
 	bar := flag.Int("bar", 123, "some int param")
 
 	envflag.Parse()
-	flag.Parse()
 
 	fmt.Println("foo", *foo)
 	fmt.Println("bar", *bar)


### PR DESCRIPTION
The overwhelmingly common case for using `envflag.Parse` is to immediately call `flag.Parse` afterword. This PR captures that common case by calling `flag.Parse` from `envflag.Parse`, simplifying the common case.

For users who do not want such functionality, `ParseFlagSet` omits such behavior. This also lets us avoid having to give an `arguments []string` parameter to `ParseFlagSet`.

To reflect this change in roles between `Parse` and `ParseFlagSet`, this PR also renames `ParseFlagSet` to `Load`.

Thank you to @jnjackins for suggestions that informed this PR.